### PR TITLE
Add import for response status

### DIFF
--- a/walkthrough/milestones/3_milestone.html
+++ b/walkthrough/milestones/3_milestone.html
@@ -199,6 +199,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Controller
 public class HomeController {


### PR DESCRIPTION
Otherwise adding:
@ResponseStatus(HttpStatus.MOVED_PERMANENTLY)
gives an error with no auto complete to import the correct annotation (on Eclipse)